### PR TITLE
Feature/implement-jwt-in-http-cookie

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "bcrypt": "^5.1.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
+        "cookie-parser": "^1.4.6",
         "handlebars": "^4.7.7",
         "nodemailer": "^6.9.5",
         "passport": "^0.6.0",
@@ -796,9 +797,9 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.0.tgz",
-      "integrity": "sha512-t/QaEvyIoIkwzpiZ7aoSKK8kObQYeF7T2v+dazAYCb8SXtp58zEVkWW7zAnju8FNKNdr4ScAOEDmMItbyOmEYw==",
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
@@ -3869,6 +3870,26 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "bcrypt": "^5.1.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
+    "cookie-parser": "^1.4.6",
     "handlebars": "^4.7.7",
     "nodemailer": "^6.9.5",
     "passport": "^0.6.0",

--- a/src/api/auth/auth.service.ts
+++ b/src/api/auth/auth.service.ts
@@ -3,23 +3,65 @@ import { JwtService } from '@nestjs/jwt';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { AuthValidateUserEvent } from './event/authValidate.event';
 import { UserValidatedEvent } from 'src/api/user/event/userValidated.event';
+import { createCipheriv, randomBytes, scrypt, createDecipheriv } from 'crypto';
+import { promisify } from 'util';
 
 @Injectable()
 export class AuthService {
+  private PASSWORD: string;
   constructor(
     private jwtService: JwtService,
     private eventEmitter: EventEmitter2,
-  ) {}
+  ) {
+    this.PASSWORD = process.env.JWT_ENCRYPTION_KEY;
+  }
 
   async generateTokens(user: { id: number; email: string }) {
-    const payload = { id: user.id, email: user.email };
+    const jwtToken = this.jwtService.sign({ id: user.id, email: user.email });
+    const encryptedToken = await this.encrypt(jwtToken);
     return {
-      access_token: this.jwtService.sign(payload),
+      access_token: encryptedToken.toString('base64'),
     };
   }
 
-  extractPayload(token: string): any {
-    return this.jwtService.decode(token);
+  async extractPayload(encryptedJwtToken: string) {
+    const decryptedJwtToken = await this.decrypt(
+      Buffer.from(encryptedJwtToken, 'base64'),
+    );
+    const payload = this.jwtService.decode(decryptedJwtToken);
+    return payload;
+  }
+
+  async encrypt(textToEncrypt: string): Promise<Buffer> {
+    const salt = randomBytes(16); // Generate a new salt for each encryption
+    const key = (await promisify(scrypt)(this.PASSWORD, salt, 32)) as Buffer; // Generate key using the salt
+    const iv = randomBytes(16); // Initialization vector
+    const cipher = createCipheriv('aes-256-ctr', key, iv);
+
+    const encryptedTextBuffer = Buffer.concat([
+      cipher.update(textToEncrypt),
+      cipher.final(),
+    ]);
+
+    // Prepend salt and IV to the encrypted data
+    return Buffer.concat([salt, iv, encryptedTextBuffer]);
+  }
+
+  async decrypt(data: Buffer): Promise<string> {
+    // Extract salt and IV from the data
+    const salt = Uint8Array.prototype.slice.call(data, 0, 16);
+    const iv = Uint8Array.prototype.slice.call(data, 16, 32);
+    const encryptedTextBuffer = Uint8Array.prototype.slice.call(data, 32);
+
+    const key = (await promisify(scrypt)(this.PASSWORD, salt, 32)) as Buffer; // Generate key using the salt
+    const decipher = createDecipheriv('aes-256-ctr', key, iv);
+
+    const decryptedTextBuffer = Buffer.concat([
+      decipher.update(encryptedTextBuffer),
+      decipher.final(),
+    ]);
+
+    return decryptedTextBuffer.toString();
   }
 
   async validateUser(email: string) {

--- a/src/api/mail/mail.service.ts
+++ b/src/api/mail/mail.service.ts
@@ -32,7 +32,7 @@ export class MailService {
     await this.mailerService.sendMail({
       to: payload.email,
       subject: `Login to ${this.appName}`,
-      template: './confirmation',
+      template: 'confirmation',
       context: {
         greeting,
         url: payload.url,
@@ -46,7 +46,7 @@ export class MailService {
     await this.mailerService.sendMail({
       to: payload.inviteeEmail,
       subject: payload.notification.title,
-      template: './notification',
+      template: 'notification',
       context: {
         title: payload.notification.title,
         data: payload.notification.data,

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { ConfigService } from '@nestjs/config';
 import { ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { API_PREFIX } from './shared/config';
+import * as cookieParser from 'cookie-parser';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { snapshot: true });
@@ -41,6 +42,8 @@ async function bootstrap() {
     credentials: true,
     allowedHeaders: 'Content-Type, Authorization',
   });
+
+  app.use(cookieParser());
 
   await app.listen(port, () => {
     console.log(`${appName}\naccess from ${serverUrl}`);

--- a/src/shared/guards/jwt-auth.guard.ts
+++ b/src/shared/guards/jwt-auth.guard.ts
@@ -10,6 +10,14 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
   }
 
   canActivate(context: ExecutionContext) {
+    const request = context.switchToHttp().getRequest();
+    const jwtCookie = request.cookies?.jwt;
+
+    // If the JWT cookie exists, set it as the Authorization header
+    if (jwtCookie) {
+      request.headers.authorization = 'Bearer ' + jwtCookie;
+    }
+
     // aknowledge SkipAuth decorator
     const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
       context.getHandler(),


### PR DESCRIPTION
This pull request updates the authentication method to store the JWT token within an HTTP-only cookie. Alongside this, the entire JWT token is now encrypted to further enhance the security of the system.

Changes Made:
Shifted from passing JWT in headers to embedding it in an HTTP-only cookie.
Implemented JWT token encryption using AES-256-CTR.
Updated the token generation and extraction methods to handle encrypted JWTs.
Added utility methods for encryption and decryption.
Benefits:
Enhanced Security: Storing JWT in HTTP-only cookies prevents frontend JavaScript code from accessing the token, reducing the risk of XSS attacks. Additionally, encrypting the JWT ensures that even if the token is intercepted, it cannot be easily deciphered without the encryption key.
Data Privacy: The user's ID and email address, which are part of the JWT payload, are now encrypted, ensuring that this sensitive information is not exposed.
Best Practices: Using HTTP-only cookies for authentication tokens is a recommended practice for modern web applications.
Future Improvements:
Consider implementing additional security measures, such as token expiration and refresh tokens.
Evaluate the performance impact, if any, of the encryption-decryption process, and optimize if necessary.
By implementing these changes, the security and privacy of the authentication strategy have been significantly improved.